### PR TITLE
Updated readme and evaluation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To use the default hyperparameters, set to False.
 |        Model        | AP     | P@20   |
 |:-------------------:|:------:|:------:|
 |  Paper 1 (two fold) | 0.2971 | 0.3948 |
-| BM25+RM3 (Anserini) | 0.2987 | 0.2871 |         
+| BM25+RM3 (Anserini) | 0.2987 | 0.3871 |         
 |     1S: BERT(QA)    | 0.3014 | 0.3928 |         
 |     2S: BERT(QA)    | 0.3003 | 0.3948 |         
 |     3S: BERT(QA)    | 0.3003 | 0.3948 |         

--- a/eval_scripts/baseline.sh
+++ b/eval_scripts/baseline.sh
@@ -17,4 +17,5 @@ fi
 
 python3 src/main/python/fine_tuning/reconstruct_robus04_tuned_run.py --index ${index_path} --folds ${folds_path} --params ${params_path}
 rm run.robust04.bm25+rm3.fold*
+mkdir --parents ${birch_path}/runs
 mv run.robust04.bm25+rm3.txt ${birch_path}/runs/run.bm25+rm3_${num_folds}cv.txt

--- a/eval_scripts/eval.sh
+++ b/eval_scripts/eval.sh
@@ -14,6 +14,6 @@ else
     echo "2S:"
     ${anserini_path}/eval/trec_eval.9.0.4/trec_eval -M1000 -m map -m P.20 "${anserini_path}/src/main/resources/topics-and-qrels/${qrels_file}" "runs/run.${experiment}.cv.ab"
 
-    echo "SS:"
+    echo "3S:"
     ${anserini_path}/eval/trec_eval.9.0.4/trec_eval -M1000 -m map -m P.20 "${anserini_path}/src/main/resources/topics-and-qrels/${qrels_file}" "runs/run.${experiment}.cv.abc"
 fi


### PR DESCRIPTION
* Fixed typo in `readme` for baseline results
* Added call in `baseline.sh` to create `runs` directory if it doesn't exist (in cases where we run baseline.sh first, or separately from the other scripts)
* Updated executable permission for `eval.sh`, and edited message in `3S` part of output

Some small changes, @zeynepakkalyoncu for visibility