### PR TITLE
Replicated arxiv paper results

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ To use the default hyperparameters, set to false.
 ### Replication Log
 
 + Results replicated by [@emmileaf](https://github.com/emmileaf) on 2019-06-10 (commit [`cc42b60`](https://github.com/castorini/birch/commit/cc42b60093090969c1d9b24cddd1257c1cad66df))
- 
- ---
++ Results replicated by [@infinitecold](https://github.com/infinitecold) on 2019-10-05 (commit [`77ac2e9`](https://github.com/castorini/birch/commit/77ac2e9f6811ceac14e1389cc2f36579c894aa08))
+
+---
 
 **How do I cite this work?**
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tar -xzvf birch_data.tar.gz
 python src/robust04_cv.py --anserini_path <path/to/anserini> --index_path <path/to/index> --cv_fold <2, 5>
 ```
 
-This step retrieves documents to depth 1000 for each query, and splits them into sentences to generate folds data. You may skip to the next step and and use the downloaded data under `data/datasets`.
+This step retrieves documents to depth 1000 for each query, and splits them into sentences to generate folds data. You may skip to the next step and use the downloaded data under `data/datasets`.
 
 ## Training
 
@@ -65,11 +65,11 @@ If you don't want to evaluate the pretrained models, you may skip to the next st
 
 - Compute document score
 
-Set the last argument to True if you want to tune the hyperparameters first.
-To use the default hyperparameters, set to False.
+Set the last argument to true if you want to tune the hyperparameters first.
+To use the default hyperparameters, set to false.
 
 ```
-./eval_scripts/test.sh <qa_2cv, mb_2cv, qa_5cv, mb_5cv> <2, 5> <path/to/anserini> <True, False>
+./eval_scripts/test.sh <qa_2cv, mb_2cv, qa_5cv, mb_5cv> <2, 5> <path/to/anserini> <true, false>
 ```
 
 - Evaluate with trec_eval

--- a/eval_scripts/test.sh
+++ b/eval_scripts/test.sh
@@ -13,10 +13,10 @@ else
     collection="robust04_2cv"
 fi
 
-if [ ${tune_params} ] ; then
+if [ ${tune_params} = true ] ; then
     declare -a sents=("a" "ab" "abc")
 
-    ./eval_scripts/train.qqsh ${experiment} ${num_folds} ${anserini_path}
+    ./eval_scripts/train.sh ${experiment} ${num_folds} ${anserini_path}
 
     for i in "${sents[@]}"
         do


### PR DESCRIPTION
Replicated results (inference then hyperparameter tuning) based on commit [`3543e65`](https://github.com/castorini/birch/tree/3543e65287e51a42d7abf9fecaf6f4f881743475) for:
- qa_2cv
- qa_5cv
- mb_2cv
- mb_5cv

Also fixed a few typos in the `eval_scripts/test.sh` script. 